### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 # This includes the license file(s) in the wheel.
 # https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 license_files = LICENSE
-description-file = README
+description_file = README


### PR DESCRIPTION
Usage of dash-separated 'description-file' will not be supported in future versions. Using the underscore name 'description_file' instead.